### PR TITLE
feat: Replace editor open with file preview, add reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fast, lightweight file explorer TUI with VSCode-like interface and Vim keybind
 - **File operations** - Copy, cut, paste, delete, rename
 - **Multi-select** - Mark multiple files with `Space`
 - **Quick search** - Incremental search with `/`
-- **Open in editor** - Launch files in `$EDITOR`
+- **File preview** - Quick view file contents (like `cat`)
 - **Hidden files toggle** - Show/hide dotfiles with `.`
 - **Path copying** - Copy file path to system clipboard
 - **File icons** - Beautiful icons with Nerd Fonts
@@ -67,14 +67,23 @@ ft ~/Documents  # Specific directory
 | `D` | Delete |
 | `r` | Rename |
 | `a` / `A` | New file / directory |
-| `o` | Open in $EDITOR |
+| `o` | Preview file |
 
 ### View
 
 | Key | Action |
 |-----|--------|
 | `.` | Toggle hidden files |
-| `R` | Refresh |
+| `R` / `F5` | Reload tree |
+
+### Preview Mode
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Scroll down / up |
+| `f` / `b` | Page down / up |
+| `g` / `G` | Jump to top / bottom |
+| `q` / `Esc` | Close preview |
 
 ### Other
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,16 +57,18 @@ fn main() -> Result<()> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> io::Result<()> {
+    let mut visible_height = 20usize;
+
     loop {
         terminal.draw(|f| {
             app.tree_area_height = f.area().height.saturating_sub(5) as usize;
-            ui::draw(f, app);
+            visible_height = ui::draw(f, app);
         })?;
 
         if event::poll(Duration::from_millis(100))? {
             match event::read()? {
                 Event::Key(key) => {
-                    input::handle_key_event(app, key);
+                    input::handle_key_event(app, key, visible_height);
                 }
                 Event::Mouse(mouse) => {
                     input::handle_mouse_event(app, mouse);


### PR DESCRIPTION
- Replace 'o' key functionality from opening in $EDITOR to inline file preview
- Preview mode shows file contents with line numbers (like cat -n)
- Binary files show hex preview
- Preview navigation: j/k (line), f/b (page), g/G (top/bottom), q/Esc (close)
- R/F5 reloads file tree and git status
- Update README with new keybindings